### PR TITLE
Completing support for passing event_reason to XNAT CR hosts

### DIFF
--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -375,7 +375,12 @@ class EObject(object):
         if DEBUG:
             print('PUT', create_uri)
 
-        output = self._intf._exec(create_uri, 'PUT', **params)
+        if 'params' in params and 'event_reason' in params['params']:
+            if DEBUG: print('Have event_reason')
+            output = self._intf._exec(create_uri, 'PUT', **params)
+        else:
+            if DEBUG: print('Not have event_reason')
+            output = self._intf._exec(create_uri, 'PUT')
 
         if is_xnat_error(output):
             paths = []

--- a/pyxnat/core/resources.py
+++ b/pyxnat/core/resources.py
@@ -1931,6 +1931,9 @@ class File(EObject):
             'inbody':'true'
             }
 
+        if 'params' in datatypes:
+            query_args.update(datatypes['params']) # Pass on params such as event_reason
+
         if '?' in self._absuri:
             k, v = self._absuri.split('?')[1].split('=')
             query_args[k] = v


### PR DESCRIPTION
Following modifications by John Flavin and Baris Kanber to allow support for passing event_reason to XNAT CR hosts.
